### PR TITLE
Update Finagle and other versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: scala
 
 scala:
-  - 2.10.4
-  - 2.11.4
+  - 2.10.5
+  - 2.11.7
 
 jdk:
   - oraclejdk7

--- a/finagle-irc/src/main/scala/com/twitter/finagle/Irc.scala
+++ b/finagle-irc/src/main/scala/com/twitter/finagle/Irc.scala
@@ -38,6 +38,9 @@ with Server[IrcHandle, Offer[Message]] {
   def newClient(name: Name, label: String): ServiceFactory[Offer[Message], IrcHandle] =
     IrcClient.newClient(name, label)
 
+  def newService(name: Name, label: String): Service[Offer[Message], IrcHandle] =
+    IrcClient.newService(name, label)
+
   def serve(addr: SocketAddress, service: ServiceFactory[IrcHandle, Offer[Message]]): ListeningServer =
     IrcServer.serve(addr, service)
 }

--- a/finagle-irc/src/main/scala/com/twitter/finagle/irc/Transport.scala
+++ b/finagle-irc/src/main/scala/com/twitter/finagle/irc/Transport.scala
@@ -43,6 +43,7 @@ case class Transport(
   def localAddress = trans.localAddress
   def remoteAddress = trans.remoteAddress
   def close(deadline: Time) = trans.close(deadline)
+  def peerCertificate: Option[java.security.cert.Certificate] = None
 
   private[this] def decode(cmdStr: String): Message = {
     // TODO: println

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,12 +2,12 @@ import sbt._
 import Keys._
 
 object FinagleIrc extends Build {
-  val libVersion = "6.24.0"
+  val libVersion = "6.29.0"
 
   val baseSettings = Defaults.defaultSettings ++ Seq(
     libraryDependencies ++= Seq(
       "com.twitter" %% "finagle-core" % libVersion,
-      "org.scalatest" %% "scalatest" % "2.2.2" % "test",
+      "org.scalatest" %% "scalatest" % "2.2.5" % "test",
       "junit" % "junit" % "4.12" % "test"
     )
   )
@@ -15,8 +15,8 @@ object FinagleIrc extends Build {
   lazy val buildSettings = Seq(
     organization := "com.github.finagle",
     version := libVersion,
-    scalaVersion := "2.10.4",
-    crossScalaVersions := Seq("2.10.4", "2.11.4"),
+    scalaVersion := "2.10.5",
+    crossScalaVersions := Seq("2.10.5", "2.11.7"),
     scalacOptions ++= Seq("-deprecation", "-feature", "-language:postfixOps")
   )
 
@@ -64,9 +64,9 @@ object FinagleIrc extends Build {
 
   lazy val finagleIrcServer =
     finProject("irc-server").settings(
-      resolvers += "twttr" at "http://maven.twttr.com/",
+      resolvers += "twttr" at "https://maven.twttr.com/",
       libraryDependencies ++= Seq(
-        "com.twitter" %% "twitter-server" % "1.9.0")
+        "com.twitter" %% "twitter-server" % "1.14.0")
     ).dependsOn(finagleIrc)
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.9


### PR DESCRIPTION
I've got more significant changes on the way, but for right now we need to move to HTTPS for maven.twttr.com since non-TLS support is going away tomorrow.
